### PR TITLE
Remove deprecation warning

### DIFF
--- a/lib/tokiyomi/time_base.rb
+++ b/lib/tokiyomi/time_base.rb
@@ -21,7 +21,7 @@ module Tokiyomi
     end
 
     def calculate(base)
-      duration.send(unit).send(direction, base)
+      duration.__send__(unit).__send__(direction, base)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ end
 
 RSpec::Matchers.define :be_calculated_to do |expect|
   match do |relative_time|
-    relative_time.calculate(now).should == Time.parse(expect)
+    expect(relative_time.calculate(now)).to eq(Time.parse(expect))
   end
 end
 require 'time'

--- a/spec/tokiyomi_spec.rb
+++ b/spec/tokiyomi_spec.rb
@@ -2,12 +2,12 @@
 require 'tokiyomi'
 
 describe Tokiyomi do
-  specify { Tokiyomi.parse('10日前').should be_kind_of(Time) }
+  specify { expect(Tokiyomi.parse('10日前')).to be_kind_of(Time) }
 
   describe '.readable?' do
-    specify { Tokiyomi.readable?('10日前').should be_true }
-    specify { Tokiyomi.readable?('日後').should be_false }
-    specify { Tokiyomi.readable?('おっととい').should be_false }
-    specify { Tokiyomi.readable?('おととい').should be_true }
+    specify { expect(Tokiyomi.readable?('10日前')).to be_truthy }
+    specify { expect(Tokiyomi.readable?('日後')).to be_falsey }
+    specify { expect(Tokiyomi.readable?('おっととい')).to be_falsey }
+    specify { expect(Tokiyomi.readable?('おととい')).to be_truthy }
   end
 end


### PR DESCRIPTION
以下2つの deprecation warning に対応してみました :santa: 
- Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect`syntax or explicitly enable `:should` instead.
- Calling #ago or #until on a number (e.g.  5.ago) is deprecated and will be removed in the future, use 5.seconds.ago instead.
